### PR TITLE
Avoid bug where partial substring match is incorrectly handled

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -182,7 +182,8 @@ module.exports = class Migrator {
       // have them on
       const importedTemplate = importedTemplates[0].replace(/.*\/templates/gi, 'templates');
 
-      const template = templateFilePaths.find((path) => path.includes(importedTemplate));
+      // include '.' to ensure we have a file extension after the name of the template, not a partial match of a longer name
+      const template = templateFilePaths.find((path) => path.includes(importedTemplate + '.'));
 
       // If we've previously put this in the "allowed" bucket, we now know it
       // *shouldn't* be allowed, because it's used in another


### PR DESCRIPTION
The codemod is seeing imports of 'some-component-name-with-more' and 'some-component-name' and treating the second as a recurrance of the first because the first name includes the second, even though they are distinct.

`templateFilePaths` is a list of absolute file paths including extension. `importedTemplate` comes from the template import statement, which doesn't include a file extension.

Adding a period to the `importedTemplate` ensures we're not unintentionally matching another longer name. In our case I expect it will always be `${importedTemplate}.hbs`